### PR TITLE
0.2.0 release

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,15 +14,14 @@ module.exports = function ( grunt ) {
     grunt.initConfig({
 
         cssmin: {
-            dist: {
-                options: {
-                    banner: '/*! banner */',
-                    report: 'gzip'
-                },
+            options: {
+                banner: '/*! banner */',
+                report: 'gzip'
+            },
+            main: {
                 files: [{
                     src: [ 'test/src/css/main.css' ],
-                    dest: 'tmp/css/main.min.css',
-                    versioningParent: 'global'
+                    dest: 'tmp/css/main.min.css'
                 }]
             }
         },
@@ -50,35 +49,38 @@ module.exports = function ( grunt ) {
         },
 
         uglify: {
-            dist: {
-                options: {
-                    mangle: true,
-                    wrap: true
-                },
+            options: {
+                mangle: true,
+                wrap: false
+            },
+            main: {
                 files: [{
                     src: [
                         'test/src/js/file1.js',
                         'test/src/js/file2.js',
                         'test/components/test/test.js'
                     ],
-                    dest: 'tmp/js/main.min.js',
-                    versioningParent: 'global'
-                }, {
+                    dest: 'tmp/js/main.min.js'
+                }]
+            },
+            plugin: {
+                files: [{
                     src: [
                         'test/src/js/file3.js',
                         'test/src/js/file4.js'
                     ],
-                    dest: 'tmp/js/plugin.min.js',
-                    versioningParent: 'global'
-                }, {
+                    dest: 'tmp/js/plugin.min.js'
+                }]
+            },
+            all: {
+                files: [{
                     src: [
                         'test/src/js/file1.js',
                         'test/src/js/file2.js',
                         'test/src/js/file3.js',
                         'test/src/js/file4.js'
                     ],
-                    dest: 'tmp/js/all.min.js',
-                    versioningParent: 'all'
+                    dest: 'tmp/js/all.min.js'
                 }]
             }
         },
@@ -92,12 +94,28 @@ module.exports = function ( grunt ) {
                     outputConfigDir: 'public/config'
                 },
                 files: [{
-                    assets: '<%= uglify.dist.files %>',
+                    assets: '<%= uglify.main.files %>',
+                    key: 'global',
                     dest: 'js',
                     type: 'js',
                     ext: '.min.js'
                 }, {
-                    assets: '<%= cssmin.dist.files %>',
+                    assets: '<%= uglify.plugin.files %>',
+                    key: 'global',
+                    dest: 'js',
+                    type: 'js',
+                    ext: '.min.js'
+                }, {
+                    assets: '<%= uglify.all.files %>',
+                    key: 'all',
+                    dest: 'js',
+                    type: 'js',
+                    ext: '.min.js'
+                },
+
+                {
+                    assets: '<%= cssmin.main.files %>',
+                    key: 'global',
                     dest: 'css',
                     type: 'css',
                     ext: '.min.css'
@@ -111,12 +129,28 @@ module.exports = function ( grunt ) {
                     namespace: 'static.assets'
                 },
                 files: [{
-                    assets: '<%= uglify.dist.files %>',
+                    assets: '<%= uglify.main.files %>',
+                    key: 'global',
                     dest: 'js',
                     type: 'js',
                     ext: '.js'
                 }, {
-                    assets: '<%= cssmin.dist.files %>',
+                    assets: '<%= uglify.plugin.files %>',
+                    key: 'global',
+                    dest: 'js',
+                    type: 'js',
+                    ext: '.js'
+                }, {
+                    assets: '<%= uglify.all.files %>',
+                    key: 'all',
+                    dest: 'js',
+                    type: 'js',
+                    ext: '.js'
+                },
+
+                {
+                    assets: '<%= cssmin.main.files %>',
+                    key: 'global',
                     dest: 'css',
                     type: 'css',
                     ext: '.css'
@@ -130,15 +164,31 @@ module.exports = function ( grunt ) {
                     namespace: 'static.assets'
                 },
                 files: [{
-                    assets: '<%= uglify.dist.files %>',
+                    assets: '<%= uglify.main.files %>',
+                    key: 'global',
                     dest: '',
                     type: 'js',
-                    ext: '.js'
+                    ext: '.min.js'
                 }, {
-                    assets: '<%= cssmin.dist.files %>',
+                    assets: '<%= uglify.plugin.files %>',
+                    key: 'global',
+                    dest: '',
+                    type: 'js',
+                    ext: '.min.js'
+                }, {
+                    assets: '<%= uglify.all.files %>',
+                    key: 'all',
+                    dest: '',
+                    type: 'js',
+                    ext: '.min.js'
+                },
+
+                {
+                    assets: '<%= cssmin.main.files %>',
+                    key: 'global',
                     dest: '',
                     type: 'css',
-                    ext: '.css'
+                    ext: '.min.css'
                 }]
             },
             prod: {
@@ -149,12 +199,28 @@ module.exports = function ( grunt ) {
                     outputConfigDir: 'public4/config'
                 },
                 files: [{
-                    assets: '<%= uglify.dist.files %>',
+                    assets: '<%= uglify.main.files %>',
+                    key: 'global',
                     dest: '',
                     type: 'js',
                     ext: '.js'
                 }, {
-                    assets: '<%= cssmin.dist.files %>',
+                    assets: '<%= uglify.plugin.files %>',
+                    key: 'global',
+                    dest: '',
+                    type: 'js',
+                    ext: '.js'
+                }, {
+                    assets: '<%= uglify.all.files %>',
+                    key: 'all',
+                    dest: '',
+                    type: 'js',
+                    ext: '.js'
+                },
+
+                {
+                    assets: '<%= cssmin.main.files %>',
+                    key: 'global',
                     dest: '',
                     type: 'css',
                     ext: '.css'
@@ -168,15 +234,31 @@ module.exports = function ( grunt ) {
                     outputConfigDir: 'public3/config'
                 },
                 files: [{
-                    assets: '<%= uglify.dist.files %>',
+                    assets: '<%= uglify.main.files %>',
+                    key: 'global',
                     dest: 'static',
                     type: 'js',
-                    ext: '.js'
+                    ext: '.min.js'
                 }, {
-                    assets: '<%= cssmin.dist.files %>',
+                    assets: '<%= uglify.plugin.files %>',
+                    key: 'global',
+                    dest: 'static',
+                    type: 'js',
+                    ext: '.min.js'
+                }, {
+                    assets: '<%= uglify.all.files %>',
+                    key: 'all',
+                    dest: 'static',
+                    type: 'js',
+                    ext: '.min.js'
+                },
+
+                {
+                    assets: '<%= cssmin.main.files %>',
+                    key: 'global',
                     dest: 'static',
                     type: 'css',
-                    ext: '.css'
+                    ext: '.min.css'
                 }]
             }
         }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,6 +63,15 @@ module.exports = function ( grunt ) {
                     dest: 'tmp/js/main.min.js'
                 }]
             },
+            skip: {
+                files: [{
+                    src: [
+                        'test/src/js/file1.js',
+                        'test/src/js/file2.js'
+                    ],
+                    dest: 'tmp/js/skip.min.js'
+                }]
+            },
             plugin: {
                 files: [{
                     src: [
@@ -108,6 +117,13 @@ module.exports = function ( grunt ) {
                 }, {
                     assets: '<%= uglify.all.files %>',
                     key: 'all',
+                    dest: 'js',
+                    type: 'js',
+                    ext: '.min.js'
+                }, {
+                    assets: '<%= uglify.skip.files %>',
+                    key: 'skip',
+                    bypass: true,
                     dest: 'js',
                     type: 'js',
                     ext: '.min.js'
@@ -181,6 +197,13 @@ module.exports = function ( grunt ) {
                     dest: '',
                     type: 'js',
                     ext: '.min.js'
+                }, {
+                    assets: '<%= uglify.skip.files %>',
+                    key: 'skip',
+                    bypass: true,
+                    dest: '',
+                    type: 'js',
+                    ext: '.min.js'
                 },
 
                 {
@@ -213,6 +236,13 @@ module.exports = function ( grunt ) {
                 }, {
                     assets: '<%= uglify.all.files %>',
                     key: 'all',
+                    dest: '',
+                    type: 'js',
+                    ext: '.js'
+                }, {
+                    assets: '<%= uglify.skip.files %>',
+                    key: 'global',
+                    bypass: true,
                     dest: '',
                     type: 'js',
                     ext: '.js'

--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ Default: ''
 
 The key is used to organize the files in the config file. The same key can be used multiple times to organized multiples files together.
 
+#### bypass
+
+Type: `Boolean`  
+Default: false
+
+If set to true, the file will bypass versioning and simply append the given extension.
+
 ### Usage Examples
 
 #### Example config
@@ -189,6 +196,7 @@ grunt.initConfig({
       }, {
         assets: '<%= uglify.plugin.files %>',
         key: 'global',
+        bypass: true,
         dest: 'js',
         type: 'js',
         ext: '.min.js'
@@ -212,7 +220,7 @@ grunt.registerTask('default', ['uglify', 'cssmin', 'versioning']);
 
 The above example would output:
 * `public/js/main.[ MD5_HASH ].min.js`
-* `public/js/plugin.[ MD5_HASH ].min.js`
+* `public/js/plugin.min.js` (no hash because of `bypass` option)
 * `public/css/main.[ MD5_HASH ].min.css`
 * `public/config/assets.config.json`
 
@@ -227,16 +235,16 @@ The above example would output:
   "staticAssets": {
     "global": {                // <--- 'key' option
       "js": [
-        "main.c2e864c8.js",
-        "plugin.24d54461.js"
+        "main.c2e864c8.min.js",
+        "plugin.min.js"
       ],
       "css": [
-        "main.b6f17edb.css"
+        "main.b6f17edb.min.css"
       ]
     },
     "all": {                   // <--- 'key' option
       "js": [
-        "all.625a4fd0.js"
+        "all.625a4fd0.min.js"
       ],
       "css": []
     }

--- a/examples/nodejs-express/versioned.helper.js
+++ b/examples/nodejs-express/versioned.helper.js
@@ -30,7 +30,7 @@ module.exports = function ( app ) {
             var obj = data.staticAssets[ key ];
             if ( obj && obj.css ) {
                 return obj.css.map( function ( src ) {
-                    return '<link rel="stylesheet" href="' + src + '"></script>';
+                    return '<link rel="stylesheet" href="' + src + '">';
                 } ).join( '\n ' );
             } else {
                 return '';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-static-versioning",
   "description": "Version static assets.",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "homepage": "https://github.com/canvaspop/grunt-static-versioning",
   "author": {
     "name": "CanvasPop",

--- a/tasks/versioning.js
+++ b/tasks/versioning.js
@@ -49,13 +49,11 @@ module.exports = function ( grunt ) {
             }
 
             file.assets.forEach( function ( asset ) {
-                var parent = asset.versioningParent,
+                var parent = file.key,
                     fileDest = file.dest === '' ? '' : ( file.dest + '/' );
 
-                // @todo Possibly find a cleaner way to get this property to the
-                // task instead of adding keys to the uglify and cssmin tasks
                 if ( !parent ) {
-                    grunt.fail.warn( 'Invalid argument : `versioningParent` property must be set' );
+                    grunt.fail.warn( 'Invalid argument : `key` property must be set' );
                 }
 
                 // store information to be able to retrieve later
@@ -68,12 +66,15 @@ module.exports = function ( grunt ) {
                     var hash = crypto.createHash( 'md5' ).update( grunt.file.read( asset.dest, 'utf8' ) ).digest( 'hex' ).substring( 0, 8 ),
                         sep = asset.dest.split( '/' ),
                         name = sep[ sep.length - 1 ].replace( /(.min)?.(js|css)/, '' ),
-                        dest = fileDest + '' + name + '.' + hash + '' + file.ext;
+                        dest = fileDest + '' + name + '.' + hash + '' + file.ext,
+                        content = grunt.file.read( asset.dest );
 
                     // push minified file only to versioning object
                     versioning[ parent ][ file.type ].push( '/' + dest );
-                    // copy file to out directory and log it
-                    grunt.file.copy( asset.dest, cwd + '' + dest );
+                    // write file to out directory and log it
+                    // this allows future content manipulation (e.g. sourcemaps)
+                    // rather than simply copying the file over
+                    grunt.file.write( cwd + '' + dest, content );
                     grunt.log.ok( 'File "' + cwd + '' + dest + '" created.' );
                 } else {
                     asset.src.forEach( function ( src ) {
@@ -132,7 +133,7 @@ module.exports = function ( grunt ) {
         var json = JSON.stringify( content, null, 2 );
         grunt.log.subhead( 'Generating JSON config file' );
         grunt.file.write( dest + '/assets.config.json', json );
-        grunt.log.ok( 'File " '+ dest + '/assets.config.json" created.' );
+        grunt.log.ok( 'File "' + dest + '/assets.config.json" created.' );
     }
 
     /**
@@ -166,7 +167,7 @@ module.exports = function ( grunt ) {
 
         grunt.log.subhead( 'Generating PHP config file' );
         grunt.file.write( dest + '/assets.config.php', contents );
-        grunt.log.ok( 'File " '+ dest + '/assets.config.php" created.' );
+        grunt.log.ok( 'File "' + dest + '/assets.config.php" created.' );
     }
 
     /**

--- a/tasks/versioning.js
+++ b/tasks/versioning.js
@@ -9,8 +9,8 @@
 'use strict';
 
 // lib to create hash
-var crypto = require( 'crypto' ),
-    util = require( 'util' );
+var crypto = require( 'crypto' );
+var util = require( 'util' );
 
 /**
  * Helper method to log objects
@@ -25,15 +25,15 @@ function inspect ( obj ) {
 module.exports = function ( grunt ) {
 
     grunt.registerMultiTask( 'versioning', 'Create md5 hash based on static assets content and append to file name', function () {
-        var versioning = {},
-            options = this.options() || {},
-            supported = /(php|json)/i,
-            target = this.target || '',
-            cwd = options.cwd || '',
-            env = options.env || 'prod',
-            output = options.output || 'json',
-            outputDir = options.outputConfigDir || cwd,
-            namespace = options.namespace || 'staticAssets';
+        var versioning = {};
+        var options = this.options() || {};
+        var supported = /(php|json)/i;
+        var target = this.target || '';
+        var cwd = options.cwd || '';
+        var env = options.env || 'prod';
+        var output = options.output || 'json';
+        var outputDir = options.outputConfigDir || cwd;
+        var namespace = options.namespace || 'staticAssets';
 
         if ( cwd !== '' ) {
             cwd += '/';
@@ -49,8 +49,8 @@ module.exports = function ( grunt ) {
             }
 
             file.assets.forEach( function ( asset ) {
-                var parent = file.key,
-                    fileDest = file.dest === '' ? '' : ( file.dest + '/' );
+                var parent = file.key;
+                var fileDest = file.dest === '' ? '' : ( file.dest + '/' );
 
                 if ( !parent ) {
                     grunt.fail.warn( 'Invalid argument : `key` property must be set' );
@@ -63,11 +63,11 @@ module.exports = function ( grunt ) {
                 // production: copy minified files over
                 // development: copy src files over
                 if ( env === 'prod' ) {
-                    var hash = crypto.createHash( 'md5' ).update( grunt.file.read( asset.dest, 'utf8' ) ).digest( 'hex' ).substring( 0, 8 ),
-                        sep = asset.dest.split( '/' ),
-                        name = sep[ sep.length - 1 ].replace( /(.min)?.(js|css)/, '' ),
-                        dest = fileDest + '' + name + '.' + hash + '' + file.ext,
-                        content = grunt.file.read( asset.dest );
+                    var hash = ( !file.bypass ) ? '.' + crypto.createHash( 'md5' ).update( grunt.file.read( asset.dest, 'utf8' ) ).digest( 'hex' ).substring( 0, 8 ) : '';
+                    var sep = asset.dest.split( '/' );
+                    var name = sep[ sep.length - 1 ].replace( /(.min)?.(js|css)/, '' );
+                    var dest = fileDest + name + hash + file.ext;
+                    var content = grunt.file.read( asset.dest );
 
                     // push minified file only to versioning object
                     versioning[ parent ][ file.type ].push( '/' + dest );

--- a/test/fixtures/expected/assets.config.dev.php
+++ b/test/fixtures/expected/assets.config.dev.php
@@ -23,5 +23,13 @@ return array(
                 '/test/src/js/file4.js',
             ),
         ),
+        'skip' => array(
+            'css' => array(
+            ),
+            'js' => array(
+                '/test/src/js/file1.js',
+                '/test/src/js/file2.js',
+            ),
+        ),
     )
 );

--- a/test/fixtures/expected/assets.config.prod.json
+++ b/test/fixtures/expected/assets.config.prod.json
@@ -2,8 +2,8 @@
   "staticAssets": {
     "global": {
       "js": [
-        "/main.c2e864c8.js",
-        "/plugin.24d54461.js"
+        "/main.cce1a4ed.js",
+        "/plugin.71f3b3f2.js"
       ],
       "css": [
         "/main.b6f17edb.css"
@@ -11,7 +11,7 @@
     },
     "all": {
       "js": [
-        "/all.625a4fd0.js"
+        "/all.3039dd25.js"
       ],
       "css": []
     }

--- a/test/fixtures/expected/assets.config.prod.json
+++ b/test/fixtures/expected/assets.config.prod.json
@@ -3,7 +3,8 @@
     "global": {
       "js": [
         "/main.cce1a4ed.js",
-        "/plugin.71f3b3f2.js"
+        "/plugin.71f3b3f2.js",
+        "/skip.js"
       ],
       "css": [
         "/main.b6f17edb.css"

--- a/test/fixtures/expected/assets.config.prod.php
+++ b/test/fixtures/expected/assets.config.prod.php
@@ -6,15 +6,15 @@ return array(
                 '/css/main.b6f17edb.css',
             ),
             'js' => array(
-                '/js/main.c2e864c8.js',
-                '/js/plugin.24d54461.js',
+                '/js/main.cce1a4ed.js',
+                '/js/plugin.71f3b3f2.js',
             ),
         ),
         'all' => array(
             'css' => array(
             ),
             'js' => array(
-                '/js/all.625a4fd0.js',
+                '/js/all.3039dd25.js',
             ),
         ),
     )

--- a/test/versioning_test.js
+++ b/test/versioning_test.js
@@ -5,9 +5,9 @@ var grunt = require( 'grunt' ),
 
 exports.versioning = {
     dist: function ( test ) {
-        test.expect( 3 );
+        test.expect( 4 );
 
-        var main, plug, style;
+        var main, plug, style, skip;
 
         try {
             main = grunt.file.read( 'public/js/main.cce1a4ed.min.js' );
@@ -18,10 +18,14 @@ exports.versioning = {
         try {
             style = grunt.file.read( 'public/css/main.b6f17edb.min.css' );
         } catch ( e ) {}
+        try {
+            skip = grunt.file.read( 'public/js/skip.min.js' );
+        } catch ( e ) {}
 
         test.ok( main, 'should have created main js file with hash' );
         test.ok( plug, 'should have created plugin js file with hash' );
         test.ok( style, 'should have created main css file with hash' );
+        test.ok( skip, 'should have created skip js file without hash' );
 
         test.done();
     },
@@ -62,7 +66,7 @@ exports.versioning = {
         test.done();
     },
     prod: function ( test ) {
-        test.expect( 6 );
+        test.expect( 7 );
 
         var config = grunt.config.get( 'versioningConfig:prod' ),
             task = grunt.config( 'versioning' ).prod,

--- a/test/versioning_test.js
+++ b/test/versioning_test.js
@@ -10,10 +10,10 @@ exports.versioning = {
         var main, plug, style;
 
         try {
-            main = grunt.file.read( 'public/js/main.c2e864c8.min.js' );
+            main = grunt.file.read( 'public/js/main.cce1a4ed.min.js' );
         } catch ( e ) {}
         try {
-            plug = grunt.file.read( 'public/js/plugin.24d54461.min.js' );
+            plug = grunt.file.read( 'public/js/plugin.71f3b3f2.min.js' );
         } catch ( e ) {}
         try {
             style = grunt.file.read( 'public/css/main.b6f17edb.min.css' );
@@ -34,10 +34,10 @@ exports.versioning = {
             expected = grunt.file.read( fixtures + '/assets.config.prod.php' );
 
         try {
-            main = grunt.file.read( 'public2/js/main.c2e864c8.js' );
+            main = grunt.file.read( 'public2/js/main.cce1a4ed.js' );
         } catch ( e ) {}
         try {
-            plug = grunt.file.read( 'public2/js/plugin.24d54461.js' );
+            plug = grunt.file.read( 'public2/js/plugin.71f3b3f2.js' );
         } catch ( e ) {}
         try {
             style = grunt.file.read( 'public2/css/main.b6f17edb.css' );


### PR DESCRIPTION
Fixes #4 
## Todo
- [x] #4 - Flag to bypass versioning

~~#5 - Add source maps support~~ Going to need to look a lot more into this. It will be added later.
## Minor release updates
- Replaced `versioningParent` option in uglify and cssmin tasks with `key` option directly in the `versioning` task
- Each outputted file is now in a separate target. This will allow future integration with source maps.
- Added `bypass` option to skip versioning a specific file
