### PR TITLE
Export php associative array and recursively get assets

### DIFF
--- a/tasks/versioning.js
+++ b/tasks/versioning.js
@@ -44,6 +44,20 @@ module.exports = function ( grunt ) {
         }
 
         this.files.forEach( function ( file ) {
+
+            if (file.orig.expand)
+            {
+                file.assets = [];
+  
+                file.src.forEach(function(filesrc) {
+                    file.assets.push({dest: filesrc, src: file.orig.cwd + '/' + file.dest});
+                    file.ext = file.orig.ext;
+                    file.dest = file.orig.dest;
+                    file.type = file.orig.type;
+                });
+
+            }
+             
             if ( !( file.assets instanceof Array ) ) {
                 grunt.fail.warn( 'Invalid argument : `assets` property must be set' );
             }
@@ -157,10 +171,10 @@ module.exports = function ( grunt ) {
             if ( obj.hasOwnProperty( key ) ) {
                 contents += '        \'' + key + '\' => array(\n';
                 contents += '            \'css\' => array(\n';
-                contents += extractFiles( obj[ key ].css );
+                contents += extractFiles( obj[ key ].css , 'php');
                 contents += '            ),\n';
                 contents += '            \'js\' => array(\n';
-                contents += extractFiles( obj[ key ].js );
+                contents += extractFiles( obj[ key ].js , 'php');
                 contents += '            ),\n';
                 contents += '        ),\n';
             }
@@ -181,11 +195,13 @@ module.exports = function ( grunt ) {
      * @param  {Array} arr Array of paths
      * @return {String}
      */
-    function extractFiles ( arr ) {
+    function extractFiles ( arr , type) {
         var contents = '';
         arr.forEach( function ( file ) {
             // space is for formatting on the output
-            contents += '                \'' + file + '\',\n';
+            if (type == 'php')
+                contents += '                 \'' + file.replace(/(.+)\/(.+)\.(.+)\.(.+)/,'$2') + '\'=>\'' + file + '\',\n';
+            else contents += '                \'' + file + '\',\n';
         });
         return contents;
     }


### PR DESCRIPTION
I thinks it is helpful to export php configuration as an associative array. Later when you implement the parser it faster to refer the files by their name. $config['css'] or $config['jquery.plugin'] instead of loop the whole array.

On the other hand, I wrote a workaround to load dynamically a bunch of files, is not perfect but it works and I didn't have to rewrite your code.

Examplse Load dynamically configuration files:

<pre>
 files: [{
          assets: '<%= cssmin.main.files %>',
          key: 'global',
          dest: 'css',
          type: 'css',
          ext: '.css'
        },
        {
          expand: true,
          cwd: '<%= js_base_path %>',
          src: '**/*.js',
          dest: '<%= js_build_path %>/js',
          key: 'global',
          dest: 'js',
          type: 'js',
          ext: '.js'
        }
]
</pre>


If you want me to write the readme or wiki let me know. thanks in advance
