### PR TITLE
Include path in filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ return array(
 
 ## Release history
 
+* 2014-04-01 0.2.2
 * 2013-12-03 0.2.1
 * 2013-09-17 0.2.0
 * 2013-08-26 0.1.1 Initial release. Not yet officially released.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-static-versioning",
   "description": "Version static assets.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "homepage": "https://github.com/canvaspop/grunt-static-versioning",
   "author": {
     "name": "CanvasPop",

--- a/tasks/versioning.js
+++ b/tasks/versioning.js
@@ -78,8 +78,9 @@ module.exports = function ( grunt ) {
                     grunt.log.ok( 'File "' + cwd + '' + dest + '" created.' );
                 } else {
                     asset.src.forEach( function ( src ) {
-                        var aFilename = src.split( '/' );
-                        var filename = aFilename[ aFilename.length - 1 ];
+                        // keep full path in the name to prevent collision
+                        var aFilename = src.replace( /\//g, '.' );
+                        var filename = aFilename;
 
                         // push source files only to versioning object
                         versioning[ parent ][ file.type ].push( '/' + fileDest + filename );

--- a/test/fixtures/expected/assets.config.dev.json
+++ b/test/fixtures/expected/assets.config.dev.json
@@ -2,22 +2,22 @@
   "staticAssets": {
     "global": {
       "js": [
-        "/static/js/file1.js",
-        "/static/js/file2.js",
-        "/static/js/test.js",
-        "/static/js/file3.js",
-        "/static/js/file4.js"
+        "/static/js/test.src.js.file1.js",
+        "/static/js/test.src.js.file2.js",
+        "/static/js/test.components.test.test.js",
+        "/static/js/test.src.js.file3.js",
+        "/static/js/test.src.js.file4.js"
       ],
       "css": [
-        "/static/css/main.css"
+        "/static/css/test.src.css.main.css"
       ]
     },
     "all": {
       "js": [
-        "/static/js/file1.js",
-        "/static/js/file2.js",
-        "/static/js/file3.js",
-        "/static/js/file4.js"
+        "/static/js/test.src.js.file1.js",
+        "/static/js/test.src.js.file2.js",
+        "/static/js/test.src.js.file3.js",
+        "/static/js/test.src.js.file4.js"
       ],
       "css": []
     }

--- a/test/fixtures/expected/assets.config.dev.php
+++ b/test/fixtures/expected/assets.config.dev.php
@@ -3,32 +3,32 @@ return array(
     'static.assets' => array(
         'global' => array(
             'css' => array(
-                '/main.css',
+                '/test.src.css.main.css',
             ),
             'js' => array(
-                '/file1.js',
-                '/file2.js',
-                '/test.js',
-                '/file3.js',
-                '/file4.js',
+                '/test.src.js.file1.js',
+                '/test.src.js.file2.js',
+                '/test.components.test.test.js',
+                '/test.src.js.file3.js',
+                '/test.src.js.file4.js',
             ),
         ),
         'all' => array(
             'css' => array(
             ),
             'js' => array(
-                '/file1.js',
-                '/file2.js',
-                '/file3.js',
-                '/file4.js',
+                '/test.src.js.file1.js',
+                '/test.src.js.file2.js',
+                '/test.src.js.file3.js',
+                '/test.src.js.file4.js',
             ),
         ),
         'skip' => array(
             'css' => array(
             ),
             'js' => array(
-                '/file1.js',
-                '/file2.js',
+                '/test.src.js.file1.js',
+                '/test.src.js.file2.js',
             ),
         ),
     )


### PR DESCRIPTION
Include the full path of files in the development output file names to prevent naming conflicts.
